### PR TITLE
Remove trailing \ in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Whether or not to cache the Pesde install and packages.\
 **Default:** `false`
 
 ### `token`
-The security token used for publishing to the Pesde marketplace.\
+The security token used for publishing to the Pesde marketplace.
 
 ## Forks
 


### PR DESCRIPTION
As this setting doesn't have a specified default on the next line, this causes the \ to be visible in the README. This PR is a small change which removes said trailing \.